### PR TITLE
Docker settings integrated into main build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+# This Dockerfile is specifically for placement in the Munki-Do git repo.
+# A separate Dockerfile in the Docker-Munki-Do repo achieves the same build by cloning
+# this repository.
+
+# Use phusion/passenger-full as base image. To make your builds reproducible, make
+# sure you lock down to a specific version, not to `latest`!
+# See https://github.com/phusion/passenger-docker/blob/master/Changelog.md for
+# a list of version numbers.
+FROM phusion/passenger-full:0.9.17
+MAINTAINER Graham Pugh <g.r.pugh@gmail.com>
+
+# Set correct environment variables.
+ENV HOME /root
+ENV DEBIAN_FRONTEND noninteractive
+ENV APP_DIR /home/app/munkido
+ENV TIME_ZONE America/New_York
+ENV APPNAME Munki-Do
+
+# Use baseimage-docker's init process.
+CMD ["/sbin/my_init"]
+
+# Install python
+RUN apt-get update && apt-get install -y \
+  openssh-server \
+  python-pip \
+  python-dev \
+  libpq-dev
+
+RUN git clone https://github.com/munki/munki.git /munki-tools
+ADD / $APP_DIR
+ADD docker/django/requirements.txt $APP_DIR/
+RUN pip install -r $APP_DIR/requirements.txt
+ADD docker/django/ $APP_DIR/munkido/
+RUN mkdir -p /var/log/django
+ADD docker/nginx/munkido.conf /etc/nginx/sites-enabled/munkido.conf
+ADD docker/run.sh /etc/my_init.d/run.sh
+RUN rm -f /etc/service/nginx/down
+RUN rm -f /etc/nginx/sites-enabled/default
+RUN groupadd munki
+RUN usermod -g munki app
+
+VOLUME ["/munki_repo", "/home/app/munkido" ]
+EXPOSE 8000
+
+#     Uncomment the following lines to copy an ssh key to the Docker image 
+# in order to allow passwordless `git push`
+# This is necessary in Bitbucket and should also work in Github
+# if you change the ssh-keyscan to `github.com`, so that you 
+# don't have to pass passwords in plain text
+#     You will need to add an `id_rsa` file to the same path as the Dockerfile,
+# as Docker cannot operate on files outside the current working directory.
+#     To generate an SSH key, follow the instructions at:
+# https://confluence.atlassian.com/bitbucket/set-up-ssh-for-git-728138079.html
+# The id_rsa file will then be found at ~/.ssh
+
+ADD docker/id_rsa /root/.ssh/id_rsa
+RUN touch /root/.ssh/known_hosts
+RUN chown root: /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+RUN ssh-keyscan bitbucket.org >> /root/.ssh/known_hosts
+
+# Clean up APT when done.
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker-machine-munki-do-start.sh
+++ b/docker-machine-munki-do-start.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Munki container
+MUNKI_REPO="/Users/glgrp/src/munki_repo"
+MUNKI_DO_DB="/Users/glgrp/src/munki-do-db"
+
+#Check that Docker Machine exists
+if [ -z "$(docker-machine ls | grep munkido)" ]; then
+	docker-machine create -d vmwarefusion munkido --vmwarefusion-disk-size=10000000
+	docker-machine env munkido
+	eval "$(docker-machine env munkido)"
+fi
+
+#Check that Docker Machine is running
+if [ "$(docker-machine status munkido)" != "Running" ]; then
+	docker-machine start munkido
+	docker-machine env munkido
+	eval "$(docker-machine env munkido)"
+fi
+
+
+# Clean up
+# This checks whether munki munki-do postgres-munkiwebadmin are running and stops them
+# if so:
+docker ps | sed "s/\ \{2,\}/$(printf '\t')/g" | \
+	awk -F"\t" '/munki|munki-do/{print $1}' | \
+	xargs docker rm -f
+
+# Run
+IP=`docker-machine ip munkido`
+echo "IP = $IP"
+
+docker run -d --restart=always --name="munki" -v $MUNKI_REPO:/munki_repo \
+	-p 80:80 -h munki groob/docker-munki
+
+# You could substitute this for git clone to a temprary folder. 
+# Make sure you delete the folder after running the container.
+#cd /path/to/docker-munki-do && \
+docker build -t="grahampugh/munki-do" .
+
+# munki-do container
+docker run -d --restart=always --name munki-do \
+	-p 8000:8000 \
+	-v $MUNKI_REPO:/munki_repo \
+	-v $MUNKI_DO_DB:/munki-do-db \
+	-e ADMIN_PASS=pass \
+	grahampugh/munki-do
+

--- a/munkido/settings_template.py
+++ b/munkido/settings_template.py
@@ -27,6 +27,7 @@ GIT_IGNORE_PKGS = 'yes'
 # If GIT_BRANCHING is enabled, users create a new branch when making a commit
 # (if that branch doesn't already exist) rather than committing to the 
 # current branch)
+#GIT_BRANCHING = 'yes'
 GIT_BRANCHING = ''
 # If Git branching is available, you should set the default branch here.
 # This is the branch which people logging into Munki-Dp will see.
@@ -41,7 +42,7 @@ MUNKI_PKG_ROOT = os.path.join(MUNKI_REPO_DIR, PKGS_DIR)
 # name of the key in a manifest file that names the user or dept
 MANIFEST_USERNAME_KEY = 'user'
 # set MANIFEST_USERNAME_IS_EDITABLE to allow edits to the displayed username
-MANIFEST_USERNAME_IS_EDITABLE = False
+MANIFEST_USERNAME_IS_EDITABLE = True
 
 # path to makecatalogs - required for packages section
 #DEFAULT_MAKECATALOGS = "/usr/local/munki/makecatalogs"
@@ -101,7 +102,7 @@ MANAGERS = ADMINS
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': os.path.join(PROJECT_DIR, 'munkiwebadmin.db'),                      # Or path to database file if using sqlite3.
+        'NAME': '/munki-do-db/munki-do.db',                      # Path to database file if using sqlite3.
         'USER': '',     # Not used with sqlite3.
         'PASSWORD': '', # Not used with sqlite3.
         'HOST': '', # Set to empty string for localhost. Not used with sqlite3.


### PR DESCRIPTION
Docker settings and docker-machine startup file now integrated into main build.

Significant simplifications made to the settings - database is now sqlite3, so no docker container is required for a postgres database (so little is done in the database in comparison to Munkiwebadmin that it's no longer worth it).
