### PR TITLE
Issue 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,8 @@ EXPOSE 8000
 
 #     Uncomment the following lines to copy an ssh key to the Docker image 
 # in order to allow passwordless `git push`
-# This is necessary in Bitbucket and should also work in Github
-# if you change the ssh-keyscan to `github.com`, so that you 
+# This is necessary in Bitbucket, Github, Gitlab etc.
+# if you change the ssh-keyscan to the domain you are connecting to, so that you 
 # don't have to pass passwords in plain text
 #     You will need to add an `id_rsa` file to the same path as the Dockerfile,
 # as Docker cannot operate on files outside the current working directory.
@@ -56,6 +56,8 @@ EXPOSE 8000
 ADD docker/id_rsa /root/.ssh/id_rsa
 RUN touch /root/.ssh/known_hosts
 RUN chown root: /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+# This dodgy line necessary for docker-gitlab, since ssh-keyscan doesn't generate the
+# correct syntax:
 RUN echo "[192.168.168.134]:10022 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLz8ILw5mJJZtF7M+HjaGx6jWUDBhKv5sJu0OrS6VBNj598g+iSWzXNZCgS/FtGHcPDnMFIEBDsJgDSLWEbE52Y= " >> /root/.ssh/known_hosts
 
 # Clean up APT when done.

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ EXPOSE 8000
 ADD docker/id_rsa /root/.ssh/id_rsa
 RUN touch /root/.ssh/known_hosts
 RUN chown root: /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-RUN ssh-keyscan bitbucket.org >> /root/.ssh/known_hosts
+RUN echo "[192.168.168.134]:10022 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLz8ILw5mJJZtF7M+HjaGx6jWUDBhKv5sJu0OrS6VBNj598g+iSWzXNZCgS/FtGHcPDnMFIEBDsJgDSLWEbE52Y= " >> /root/.ssh/known_hosts
 
 # Clean up APT when done.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker/django/requirements.txt
+++ b/docker/django/requirements.txt
@@ -1,3 +1,3 @@
-Django==1.7.2
+django==1.7.2
 django-tokenapi==0.2.2
 psycopg2==2.5.5

--- a/manifests/models.py
+++ b/manifests/models.py
@@ -111,11 +111,10 @@ class MunkiGit:
 #            self.runGit(['push', '--set-upstream' 'origin', branch_name])
             logger.info("Checked out branch %s" % branch_name)
 
-    def commitFileAtPathForCommitter(self, aPath, committer):
+    def commitFileAtPathForCommitter(self, aPath, branch_name, committer):
         """Commits the file at 'aPath'. This method will also automatically
         generate the commit log appropriate for the status of aPath where status
         would be 'modified', 'new file', or 'deleted'"""
-        branch_name = None
         self.__chdirToMatchPath(aPath)
         # get the author information
         author_name = committer.first_name + ' ' + committer.last_name
@@ -197,6 +196,8 @@ class MunkiGit:
                     del manifest['new_manifest']
             else:
                 branch_name = self.checkoutUserBranch(aCommitter)
+        else:
+            branch_name = None
         try:
             plistlib.writePlist(manifest, aPath)
             logger.info("Wrote plist at %s" % (aPath))
@@ -208,7 +209,7 @@ class MunkiGit:
         if not 'new_manifest' in manifest:
             self.runGit(['add', aPath])
             if self.results['returncode'] == 0:
-                self.commitFileAtPathForCommitter(aPath, aCommitter)
+                self.commitFileAtPathForCommitter(aPath, branch_name, aCommitter)
         return 0
 
 
@@ -219,10 +220,12 @@ class MunkiGit:
         # If Git branching is enabled, create a new branch
         if GIT_BRANCHING:
             branch_name = self.checkoutUserBranch(aCommitter)
+        else:
+            branch_name = None
 
         self.runGit(['rm', aPath])
         if self.results['returncode'] == 0:
-            self.commitFileAtPathForCommitter(aPath, aCommitter)
+            self.commitFileAtPathForCommitter(aPath, branch_name, aCommitter)
         return 0
 
 

--- a/manifests/templates/manifests/detail.html
+++ b/manifests/templates/manifests/detail.html
@@ -148,6 +148,11 @@
 	</div>
 	<div id="data_storage" data-autocomplete_data='{{ autocomplete_data }}' />
 	<div id="csrf_token" style='display:none'>{% csrf_token %}</div>
+{% elif git_branching_enabled %}
+	<div id="item_name">Git branching enabled. Please refresh your view or click below:</div>
+	<div class="btn">
+		<a id='git-pull' onclick="location.href='{% url "manifests.views.gitpull" %}';">Update view (git pull)</a>
+	</div>
 {% else %}
-    <div id="item_name">Manifest is empty</div>
+	<div id="item_name">Manifest is empty</div>
 {% endif %}

--- a/manifests/templates/manifests/detail.html
+++ b/manifests/templates/manifests/detail.html
@@ -11,6 +11,32 @@
 	  	</div>
 	</h3>
 	<div id="manifest_detail" style="height: 100%; overflow-y: scroll; padding-top:10px;">
+		{% if user %}
+		  <div class='manifest_section'>
+		  <div class="section_label">User</div>
+			<ul id='_user_name' class='section unstyled'>
+				<li id='{{ manifest_user }}' class='nameitem'>
+				{%  if manifest_user_is_editable %}
+					<div class='editable user_name_field'>{{ manifest_user }}</div>
+				{% else %}
+					{{ manifest_user }}
+				{% endif %}
+				</li>
+			</ul>
+			</div>
+		{% endif %}
+		
+<!-- 
+		<div class='manifest_section'>
+		<div class="section_label">User restrictions</div>
+		<ul id='restriction' class='section unstyled'>
+			<li id='{{ manifest.restriction }}' class='nameitem'>
+				<div class='editable'>{{ manifest.restriction }}</div>
+			</li>
+		</ul>
+		</div>
+		
+ -->
 		<div class='manifest_section'>
 		<div class="section_label">Catalogs</div>
 		<ul id='catalogs' class='catalogs_section list-group unstyled'>
@@ -34,7 +60,7 @@
 			
 		</ul>
 		</div>
-		
+
 		{% if manifest.conditional_items %}
 		<div class='manifest_section'>
 		<div class="section_label">Conditional Items</div>

--- a/manifests/views.py
+++ b/manifests/views.py
@@ -187,6 +187,10 @@ def detail(request, manifest_name):
         })
         manifest_user = manifest.get(MANIFEST_USERNAME_KEY, '')
         
+        git_branching_enabled = None
+        if GIT_BRANCHING:
+            git_branching_enabled = GIT_BRANCHING
+
         c = RequestContext(request, 
             {'manifest_name': manifest_name.replace(':', '/'),
             'manifest_user': manifest_user,
@@ -197,6 +201,7 @@ def detail(request, manifest_name):
             'valid_catalogs': valid_catalogs,
             'valid_manifest_names': valid_manifest_names,
             'autocomplete_data': autocomplete_data,
+            'git_branching_enabled': git_branching_enabled,
             'user': request.user,
             'page': 'manifests'})
         c.update(csrf(request))


### PR DESCRIPTION
Issue 9 is now resolved. git-commit is held back after manifest creation, and a temporary key is used to identify the branch created at the time of manifest creation, which is then re-checked-out after the first change is made to the manifest. As long as the branch is not deleted from the machine on which the user made the change (normally the server), then there should be no issue checking out this branch. 
