### PR TITLE
Issue 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # sure you lock down to a specific version, not to `latest`!
 # See https://github.com/phusion/passenger-docker/blob/master/Changelog.md for
 # a list of version numbers.
-FROM phusion/passenger-full:0.9.17
+FROM phusion/passenger-full:0.9.19
 MAINTAINER Graham Pugh <g.r.pugh@gmail.com>
 
 # Set correct environment variables.

--- a/docker-machine-munki-do-start.sh
+++ b/docker-machine-munki-do-start.sh
@@ -10,8 +10,6 @@ MUNKI_PORT=8080
 MUNKI_DO_DB="/Users/Shared/munki-do-db"
 # Set the public port on which you wish to access Munki-Do
 MUNKI_DO_PORT=8000
-# Set Munki-Do manifest item search to all items rather than just in current catalog:
-DOCKER_MUNKIDO_ALL_ITEMS=true
 # Create a new folder to house the Sal Django database and point to it here.
 # If using Docker-Machine, it must be within /Users somewhere:
 SAL_DB="/Users/Shared/sal-db"
@@ -23,8 +21,18 @@ MWA2_DB="/Users/Shared/mwa2-db"
 # Set the public port on which you wish to access MWA2 
 MWA2_PORT=8082
 
+## These are MUNKI-DO specific options:
+
+# Set Munki-Do manifest item search to all items rather than just in current catalog:
+ALL_ITEMS=true
+# Munki-Do opens on the 'catalog' pages by default. Set to "pkgs" or "manifest" if you 
+# wish to change this behaviour:
+LOGIN_REDIRECT_URL="pkgs"
+# Munki-Do timezone is 'Europe/Zurich' by default, but you can change to whatever you 
+# wish using the codes listed at http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
+TIME_ZONE = 'Europe/Zurich'
 # Comment this out or set to '' to disable git
-#	GIT_PATH='/usr/bin/git'
+#GIT_PATH='/usr/bin/git'
 # Comment this out or leave blank to disable git branching 
 # (so all commits are done to master branch).
 # Or set to any value, e.g.'yes', 'no', 'fred', in order to enable git branching.
@@ -151,6 +159,9 @@ docker run -d --restart=always --name munki-do \
 	-p $MUNKI_DO_PORT:8000 \
 	-v $MUNKI_REPO:/munki_repo \
 	-v $MUNKI_DO_DB:/munki-do-db \
+	-e DOCKER_MUNKIDO_TIME_ZONE="$TIME_ZONE" \
+	-e DOCKER_MUNKIDO_LOGIN_REDIRECT_URL="$LOGIN_REDIRECT_URL" \
+	-e DOCKER_MUNKIDO_ALL_ITEMS="$ALL_ITEMS" \
 	-e DOCKER_MUNKIDO_GIT_PATH="$GIT_PATH" \
 	-e DOCKER_MUNKIDO_GIT_BRANCHING="$GIT_BRANCHING" \
 	-e DOCKER_MUNKIDO_GIT_IGNORE_PKGS="$GIT_IGNORE_PKGS" \

--- a/docker-machine-munki-do-start.sh
+++ b/docker-machine-munki-do-start.sh
@@ -25,9 +25,9 @@ MWA2_PORT=8082
 
 # Set Munki-Do manifest item search to all items rather than just in current catalog:
 ALL_ITEMS=true
-# Munki-Do opens on the 'catalog' pages by default. Set to "pkgs" or "manifest" if you 
+# Munki-Do opens on the '/catalog' pages by default. Set to "/pkgs" or "/manifest" if you 
 # wish to change this behaviour:
-LOGIN_REDIRECT_URL="pkgs"
+LOGIN_REDIRECT_URL="/pkgs"
 # Munki-Do timezone is 'Europe/Zurich' by default, but you can change to whatever you 
 # wish using the codes listed at http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 TIME_ZONE='Europe/Zurich'

--- a/docker-machine-munki-do-start.sh
+++ b/docker-machine-munki-do-start.sh
@@ -30,7 +30,7 @@ ALL_ITEMS=true
 LOGIN_REDIRECT_URL="pkgs"
 # Munki-Do timezone is 'Europe/Zurich' by default, but you can change to whatever you 
 # wish using the codes listed at http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
-TIME_ZONE = 'Europe/Zurich'
+TIME_ZONE='Europe/Zurich'
 # Comment this out or set to '' to disable git
 #GIT_PATH='/usr/bin/git'
 # Comment this out or leave blank to disable git branching 

--- a/docker-machine-munki-do-start.sh
+++ b/docker-machine-munki-do-start.sh
@@ -54,7 +54,6 @@ if [ "$(docker-machine status munkido)" != "Running" ]; then
     VBoxManage modifyvm "munkido" --natpf1 delete munki
     VBoxManage modifyvm "munkido" --natpf1 delete mwa2
     VBoxManage modifyvm "munkido" --natpf1 delete sal
-    VBoxManage modifyvm "munkido" --natpf1 delete sal-udp
     # setup the required port forwarding on the VM
     VBoxManage modifyvm "munkido" --natpf1 "munki-do,tcp,,$MUNKI_DO_PORT,,$MUNKI_DO_PORT"
     VBoxManage modifyvm "munkido" --natpf1 "munki,tcp,,$MUNKI_PORT,,$MUNKI_PORT"
@@ -73,7 +72,7 @@ IP=`docker-machine ip munkido`
 # This checks whether munki munki-do etc are running and stops them
 # if so (thanks to Pepijn Bruienne):
 docker ps -a | sed "s/\ \{2,\}/$(printf '\t')/g" | \
-	awk -F"\t" '/munki|munki-do|sal|postgres-sal|gitlab|gitlab-postgresql|gitlab-redis/{print $1}' | \
+	awk -F"\t" '/munki|munki-do|mwa2|sal|postgres-sal|gitlab|gitlab-postgresql|gitlab-redis/{print $1}' | \
 	xargs docker rm -f
 	
 ## GITLAB settings

--- a/docker-machine-munki-do-start.sh
+++ b/docker-machine-munki-do-start.sh
@@ -19,7 +19,7 @@ SAL_PORT=8081
 # If using Docker-Machine, it must be within /Users somewhere:
 MWA2_DB="/Users/Shared/mwa2-db"
 # Set the public port on which you wish to access MWA2 
-MWA_PORT=8082
+MWA2_PORT=8082
 
 # Comment this out or set to '' to disable git
 #	GIT_PATH='/usr/bin/git'
@@ -163,7 +163,7 @@ docker run -d --restart=always --name munki-do \
 
 # munki-do container
 docker run -d --restart=always --name mwa2 \
-	-p $MWA_PORT:8000 \
+	-p $MWA2_PORT:8000 \
 	-v $MUNKI_REPO:/munki_repo \
 	-v $MWA2_DB:/mwa2-db \
 	grahamrpugh/mwa2
@@ -180,6 +180,7 @@ docker run -d --name="sal" \
 
 echo
 echo "### Your Docker Machine IP is: $IP"
+echo "### Your MunkiWebAdmin2 URL is: http://$IP:$MWA2_PORT"
 echo "### Your Munki-Do URL is: http://$IP:$MUNKI_DO_PORT"
 echo "### Your Sal URL is: http://$IP:$SAL_PORT"
 echo "### Test your Munki URL with: http://$IP:$MUNKI_PORT/repo/catalogs/all"

--- a/docker-machine-munki-do-start.sh
+++ b/docker-machine-munki-do-start.sh
@@ -10,6 +10,8 @@ MUNKI_PORT=8080
 MUNKI_DO_DB="/Users/Shared/munki-do-db"
 # Set the public port on which you wish to access Munki-Do
 MUNKI_DO_PORT=8000
+# Set Munki-Do manifest item search to all items rather than just in current catalog:
+DOCKER_MUNKIDO_ALL_ITEMS=true
 # Create a new folder to house the Sal Django database and point to it here.
 # If using Docker-Machine, it must be within /Users somewhere:
 SAL_DB="/Users/Shared/sal-db"

--- a/docker-machine-munki-do-start.sh
+++ b/docker-machine-munki-do-start.sh
@@ -126,12 +126,12 @@ fi
 
 # ensuring the Munki-Do DB folder exists with the correct permissions
 if [ ! -d "$MUNKI_DO_DB" ]; then
-    mkdir -p $MUNKI_DO_DB
+    mkdir -p "$MUNKI_DO_DB"
     # chmod and chown if you need to!
 fi
 
 if [ ! -d "$SAL_DB" ]; then
-    mkdir -p $SAL_DB
+    mkdir -p "$SAL_DB"
     # chmod and chown if you need to!
 fi
 
@@ -180,9 +180,9 @@ docker run -d --name="sal" \
 
 echo
 echo "### Your Docker Machine IP is: $IP"
-echo "### Your Munki-Do URL is: http://$IP:MUNKI_DO_PORT"
-echo "### Your Sal URL is: http://$IP:SAL_PORT"
-echo "### Test your Munki URL with: http://$IP:MUNKI_PORT/repo/catalogs/all"
+echo "### Your Munki-Do URL is: http://$IP:$MUNKI_DO_PORT"
+echo "### Your Sal URL is: http://$IP:$SAL_PORT"
+echo "### Test your Munki URL with: http://$IP:$MUNKI_PORT/repo/catalogs/all"
 if [ $GITLAB_DATA ]; then
 	echo "### Your Gitlab URL is: http://$IP:10080"
 fi

--- a/docker-machine-munki-do-start.sh
+++ b/docker-machine-munki-do-start.sh
@@ -17,7 +17,7 @@ SAL_DB="/Users/Shared/sal-db"
 SAL_PORT=8081
 # Create a new folder to house the MWA2 Django database and point to it here:
 # If using Docker-Machine, it must be within /Users somewhere:
-MWA2_DB="/Users/glgrp/src/mwa2-db"
+MWA2_DB="/Users/Shared/mwa2-db"
 # Set the public port on which you wish to access MWA2 
 MWA_PORT=8082
 

--- a/docker-machine-munki-do-start.sh
+++ b/docker-machine-munki-do-start.sh
@@ -176,15 +176,17 @@ docker run -d --name="sal" \
   -p $SAL_PORT:8000 \
   -v $SAL_DB:/home/docker/sal/db \
   -e ADMIN_PASS=pass \
-  -e DOCKER_SAL_TZ="America/New_York" \
+  -e DOCKER_SAL_TZ="Europe/Berlin" \
   macadmins/sal
 
 echo
 echo "### Your Docker Machine IP is: $IP"
-echo "### Your Munki-Do URL is: http://$IP:8000"
-echo "### Your Sal URL is: http://$IP:8081"
-echo "### Test your Munki URL with: http://$IP:8080/repo/catalogs/all"
-echo "### Your Gitlab URL is: http://$IP:10080"
+echo "### Your Munki-Do URL is: http://$IP:MUNKI_DO_PORT"
+echo "### Your Sal URL is: http://$IP:SAL_PORT"
+echo "### Test your Munki URL with: http://$IP:MUNKI_PORT/repo/catalogs/all"
+if [ $GITLAB_DATA ]; then
+	echo "### Your Gitlab URL is: http://$IP:10080"
+fi
 echo
 
 

--- a/manifests/models.py
+++ b/manifests/models.py
@@ -366,21 +366,21 @@ class Manifest(object):
                 catalog_items = Catalog.detail(catalog)
                 if catalog_items:
                     suggested_names = list(set(
-                        [item['name'] for item in catalog_items.order_by('item')
+                        [item['name'] for item in catalog_items
                          if not item.get('update_for')]))
                     suggested_set.update(suggested_names)
                     update_names = list(set(
-                        [item['name'] for item in catalog_items.order_by('item')
+                        [item['name'] for item in catalog_items
                          if item.get('update_for')]))
                     update_set.update(update_names)
                     item_names_with_versions = list(set(
                         [item['name'] + '-' + 
                         trimVersionString(item['version'])
-                        for item in catalog_items.order_by('item')]))
+                        for item in catalog_items]))
                     versioned_set.update(item_names_with_versions)
-        return {'suggested': list(suggested_set),
-                'updates': list(update_set),
-                'with_version': list(versioned_set)}
+        return {'suggested': sorted(list(suggested_set)),
+                'updates': sorted(list(update_set)),
+                'with_version': sorted(list(versioned_set))}
 
     @classmethod
     def findUserForManifest(cls, manifest_name):

--- a/manifests/models.py
+++ b/manifests/models.py
@@ -378,9 +378,9 @@ class Manifest(object):
                         trimVersionString(item['version'])
                         for item in catalog_items]))
                     versioned_set.update(item_names_with_versions)
-        return {'suggested': list(suggested_set),
-                'updates': list(update_set),
-                'with_version': list(versioned_set)}
+        return {'suggested': list(suggested_set.order_by('item')),
+                'updates': list(update_set.order_by('item')),
+                'with_version': list(versioned_set.order_by('item'))}
 
     @classmethod
     def findUserForManifest(cls, manifest_name):

--- a/manifests/models.py
+++ b/manifests/models.py
@@ -366,21 +366,21 @@ class Manifest(object):
                 catalog_items = Catalog.detail(catalog)
                 if catalog_items:
                     suggested_names = list(set(
-                        [item['name'] for item in catalog_items
+                        [item['name'] for item in catalog_items.order_by('item')
                          if not item.get('update_for')]))
                     suggested_set.update(suggested_names)
                     update_names = list(set(
-                        [item['name'] for item in catalog_items
+                        [item['name'] for item in catalog_items.order_by('item')
                          if item.get('update_for')]))
                     update_set.update(update_names)
                     item_names_with_versions = list(set(
                         [item['name'] + '-' + 
                         trimVersionString(item['version'])
-                        for item in catalog_items]))
+                        for item in catalog_items.order_by('item')]))
                     versioned_set.update(item_names_with_versions)
-        return {'suggested': list(suggested_set.order_by('item')),
-                'updates': list(update_set.order_by('item')),
-                'with_version': list(versioned_set.order_by('item'))}
+        return {'suggested': list(suggested_set),
+                'updates': list(update_set),
+                'with_version': list(versioned_set)}
 
     @classmethod
     def findUserForManifest(cls, manifest_name):

--- a/manifests/static/js/manifests.js
+++ b/manifests/static/js/manifests.js
@@ -156,7 +156,7 @@ function makeEditableItems(manifest_name) {
     });
     $('.section_label').append("<a class='btn-xs btn-success btn-mini add_item pull-right' href='#'>+</a>");
     $('.add_item').click(function() {
-        var list_item = $("<li class='list-group-item entrys'><span class='btn-xs btn-danger btn-mini lineitem_delete pull-right' style='margin-top:4px;'>-</span><div class='editable'>-</div></li>");
+        var list_item = $("<li class='list-group-item entrys'><span class='btn-xs btn-danger btn-mini lineitem_delete pull-right' style='margin-top:4px;'>-</span><div class='editable'></div></li>");
         $(this).parent().siblings($('ul')).append(list_item);
         makeEditableItem(
             manifest_name, autocomplete_data, list_item.children(".editable"));

--- a/manifests/templates/manifests/detail.html
+++ b/manifests/templates/manifests/detail.html
@@ -99,7 +99,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Managed Installs</div>
 			<ul id='managed_installs' class='section list-group unstyled'>
-				{% for item in manifest.managed_installs %}
+				{% for item in manifest.managed_installs|dictsort:"lstrip" %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger
@@ -113,7 +113,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Managed Uninstalls</div>
 			<ul id='managed_uninstalls' class='section list-group unstyled'>
-				{% for item in manifest.managed_uninstalls %}
+				{% for item in manifest.managed_uninstalls|dictsort:"lstrip" %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger
@@ -128,7 +128,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Managed Updates</div>
 			<ul id='managed_updates' class='section list-group unstyled'>
-				{% for item in manifest.managed_updates %}
+				{% for item in manifest.managed_updates|dictsort:"lstrip" %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger

--- a/manifests/templates/manifests/detail.html
+++ b/manifests/templates/manifests/detail.html
@@ -99,7 +99,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Managed Installs</div>
 			<ul id='managed_installs' class='section list-group unstyled'>
-				{% for item in manifest.managed_installs|dictsort:"item" %}
+				{% for item in manifest.managed_installs.all|dictsort:"item" %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger
@@ -113,7 +113,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Managed Uninstalls</div>
 			<ul id='managed_uninstalls' class='section list-group unstyled'>
-				{% for item in manifest.managed_uninstalls|dictsort:"item" %}
+				{% for item in manifest.managed_uninstalls.all|dictsort:"item" %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger
@@ -128,7 +128,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Managed Updates</div>
 			<ul id='managed_updates' class='section list-group unstyled'>
-				{% for item in manifest.managed_updates|dictsort:"item" %}
+				{% for item in manifest.managed_updates.all|dictsort:"item" %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger
@@ -143,7 +143,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Optional Installs</div>
 			<ul id='optional_installs' class='section list-group unstyled'>
-				{% for item in manifest.optional_installs|dictsort:"item" %}
+				{% for item in manifest.optional_installs.all|dictsort:"item" %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger

--- a/manifests/templates/manifests/detail.html
+++ b/manifests/templates/manifests/detail.html
@@ -143,7 +143,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Optional Installs</div>
 			<ul id='optional_installs' class='section list-group unstyled'>
-				{% for item in manifest.optional_installs %}
+				{% for item in manifest.optional_installs|dictsort:"optional_installs" %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger

--- a/manifests/templates/manifests/detail.html
+++ b/manifests/templates/manifests/detail.html
@@ -143,7 +143,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Optional Installs</div>
 			<ul id='optional_installs' class='section list-group unstyled'>
-				{% for item in manifest.optional_installs|dictsort:0 %}
+				{% for item in manifest.optional_installs|dictsort:"item" %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger

--- a/manifests/templates/manifests/detail.html
+++ b/manifests/templates/manifests/detail.html
@@ -143,7 +143,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Optional Installs</div>
 			<ul id='optional_installs' class='section list-group unstyled'>
-				{% for item in manifest.optional_installs:dictsort:0 %}
+				{% for item in manifest.optional_installs|dictsort:0 %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger

--- a/manifests/templates/manifests/detail.html
+++ b/manifests/templates/manifests/detail.html
@@ -99,7 +99,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Managed Installs</div>
 			<ul id='managed_installs' class='section list-group unstyled'>
-				{% for item in manifest.managed_installs %}
+				{% for item in manifest.managed_installs|dictsort:"item" %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger
@@ -113,7 +113,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Managed Uninstalls</div>
 			<ul id='managed_uninstalls' class='section list-group unstyled'>
-				{% for item in manifest.managed_uninstalls %}
+				{% for item in manifest.managed_uninstalls|dictsort:"item" %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger
@@ -128,7 +128,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Managed Updates</div>
 			<ul id='managed_updates' class='section list-group unstyled'>
-				{% for item in manifest.managed_updates %}
+				{% for item in manifest.managed_updates|dictsort:"item" %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger
@@ -143,7 +143,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Optional Installs</div>
 			<ul id='optional_installs' class='section list-group unstyled'>
-				{% for item in manifest.optional_installs %}
+				{% for item in manifest.optional_installs|dictsort:"item" %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger

--- a/manifests/templates/manifests/detail.html
+++ b/manifests/templates/manifests/detail.html
@@ -143,7 +143,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Optional Installs</div>
 			<ul id='optional_installs' class='section list-group unstyled'>
-				{% for item in manifest.optional_installs|dictsort:"optional_installs" %}
+				{% for item in manifest.optional_installs:dictsort:0 %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger

--- a/manifests/templates/manifests/detail.html
+++ b/manifests/templates/manifests/detail.html
@@ -143,7 +143,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Optional Installs</div>
 			<ul id='optional_installs' class='section list-group unstyled'>
-				{% for item in manifest.optional_installs|dictsort:"item" %}
+				{% for item in manifest.optional_installs|dictsort:"lstrip" %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger

--- a/manifests/templates/manifests/detail.html
+++ b/manifests/templates/manifests/detail.html
@@ -99,7 +99,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Managed Installs</div>
 			<ul id='managed_installs' class='section list-group unstyled'>
-				{% for item in manifest.managed_installs.all|dictsort:"item" %}
+				{% for item in manifest.managed_installs %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger
@@ -113,7 +113,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Managed Uninstalls</div>
 			<ul id='managed_uninstalls' class='section list-group unstyled'>
-				{% for item in manifest.managed_uninstalls.all|dictsort:"item" %}
+				{% for item in manifest.managed_uninstalls %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger
@@ -128,7 +128,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Managed Updates</div>
 			<ul id='managed_updates' class='section list-group unstyled'>
-				{% for item in manifest.managed_updates.all|dictsort:"item" %}
+				{% for item in manifest.managed_updates %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger
@@ -143,7 +143,7 @@
 		<div class='manifest_section'>
 			<div class="section_label">Optional Installs</div>
 			<ul id='optional_installs' class='section list-group unstyled'>
-				{% for item in manifest.optional_installs.all|dictsort:"item" %}
+				{% for item in manifest.optional_installs %}
 					<li id='{{ item }}' class='list-group-item entrys 
 					{% if manifest.catalogs and item not in valid_install_items %}
 						list-group-item-danger

--- a/manifests/templates/manifests/index.html
+++ b/manifests/templates/manifests/index.html
@@ -54,7 +54,7 @@
 				{% if manifest_list %}
 				{% url "manifests.views.index" as the_url %}
 				<div id="listsmall" class="list-group" style="font-size:12pt; overflow-y: scroll; max-height:250px;">
-					{% for manifest in manifest_list|dictsort:"lstrip"  %}
+					{% for manifest in manifest_list|dictsort:"name"  %}
 					<a class='manifest list-group-item' data-state='all' id='{{ manifest.name }}' href='#'>{{ manifest.name }}</a>
 					{% endfor %}
 				</div>

--- a/manifests/templates/manifests/index.html
+++ b/manifests/templates/manifests/index.html
@@ -54,7 +54,7 @@
 				{% if manifest_list %}
 				{% url "manifests.views.index" as the_url %}
 				<div id="listsmall" class="list-group" style="font-size:12pt; overflow-y: scroll; max-height:250px;">
-					{% for manifest in manifest_list|dictsort:"name"  %}
+					{% for manifest in manifest_list|dictsort:"lstrip"  %}
 					<a class='manifest list-group-item' data-state='all' id='{{ manifest.name }}' href='#'>{{ manifest.name }}</a>
 					{% endfor %}
 				</div>

--- a/munkido/custom_tags.py
+++ b/munkido/custom_tags.py
@@ -1,0 +1,6 @@
+from django import template
+register = template.Library()
+
+@register.filter
+def sort_by(queryset, order):
+    return queryset.order_by(order)

--- a/munkido/settings_template.py
+++ b/munkido/settings_template.py
@@ -129,7 +129,7 @@ DATABASES = {
 # timezone as the operating system.
 # If running in a Windows environment this must be set to the same as your
 # system time zone.
-TIME_ZONE = 'America/New_York'
+TIME_ZONE = 'Europe/Zurich'
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
@@ -201,7 +201,7 @@ else:
     )
 
 LOGIN_URL='/login/'
-LOGIN_REDIRECT_URL='/catalog'
+LOGIN_REDIRECT_URL='/catalogs'
 
 ROOT_URLCONF = 'munkido.urls'
 


### PR DESCRIPTION
Dash now removed from manifest list package additions.
Additionally, the lists are now sorted correctly.
Also, more options have been added to the startup script: 
- the login redirect, which allows you to start on the pkgs, manifests or catalog pages
- the time zone
- the ALL_ITEMS option which allows you to search for packages that are not in the manifest's catalog list (most useful when your manifest doesn't have any catalog).
